### PR TITLE
ci: Update GitHub Windows runner image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macOS-latest, windows-2019, ubuntu-latest]
+        os: [macOS-latest, windows-latest, ubuntu-latest]
     name: cargo clippy
     steps:
       - uses: actions/checkout@v4
@@ -75,7 +75,7 @@ jobs:
     needs: find-msrv
     strategy:
       matrix:
-        os: [macOS-latest, windows-2019, ubuntu-latest]
+        os: [macOS-latest, windows-latest, ubuntu-latest]
     name: cargo test
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Like in the main repo, I think it is safe to use the latest version of the image, rather than pinning a specific one.