### PR TITLE
fix: Update minimum supported Rust version to 1.77.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ When reporting an issue, in order to help the maintainers understand what the pr
 
 When making a code contribution to AccessKit, before opening your pull request please make sure that:
 
-- your patch builds with AccessKit's minimal supported Rust version (currently Rust 1.75)
+- your patch builds with AccessKit's minimal supported Rust version (currently Rust 1.77.2)
 - you added tests where applicable
 - you tested your modifications on all impacted platforms (see below)
 - you updated any relevant documentation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "Python bindings to the AccessKit library"
 readme = "README.md"
 publish = false
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.77.2"
 
 [lib]
 name = "accesskit"


### PR DESCRIPTION
Prerequisite for #6 

The cargo-deny CI check will probably fail. It will be fixed by the aforementionned PR.