### PR TITLE
chore: Configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "fix"
+    groups:
+      rust-crates:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+    groups:
+      ci:
+        patterns:
+          - "*"


### PR DESCRIPTION
Similar to https://github.com/AccessKit/accesskit-c/pull/6

This tells Dependabot to check for dependency updates once per week and open PRs as needed.

- All updates to Rust dependencies will be grouped in one PR, with "fix: " at the start of its title,
- All updates to GitHub Actions in the workflows will be grouped in one PR, with "chore: " at the start of its title.

Merging this PR should immediately trigger a new scan of the repository.